### PR TITLE
Update 2.80 (backwards compatible) + extra...

### DIFF
--- a/cs_change_frame.py
+++ b/cs_change_frame.py
@@ -37,8 +37,45 @@ is27 = bool(bpy.app.version < (2, 80, 0))
 
 if (is27):
     context_prefs = '''bpy.context.user_preferences.addons[%r].preferences''' % __name__
+    sym = ' = '
 if (is28):
     context_prefs = '''bpy.context.preferences.addons[%r].preferences''' % __name__
+    sym = ': '
+
+# ==========================================================
+bprops = [
+    'BoolProperty',
+    'BoolVectorProperty',
+    'IntProperty',
+    'IntVectorProperty',
+    'FloatProperty',
+    'FloatVectorProperty',
+    'StringProperty',
+    'EnumProperty',
+    'PointerProperty',
+    'CollectionProperty',
+    'RemoveProperty',
+    ]
+bprops = [eval('bpy.props.%s' % b) for b in bprops]
+
+
+def register_props(cls):
+    txt = ''
+
+    if type(cls) is type:
+        # blank class
+        name = cls.__name__
+        for var in cls.__dict__:
+            prop = cls.__dict__[var]
+            if not prop or type(prop) is not tuple:
+                continue
+
+            # if prop[0] in bpy.props.__dict__.items():
+                #   # This version includes the Properties plus hidden props, that you'd never run into anyway; either one works
+            if prop[0] in bprops:
+                txt += "%s%s%s.%s; " % (var, sym, name, var)
+    return txt
+# ==========================================================
 
 
 class CENDA_OT_ChangeFrame(Operator):
@@ -48,14 +85,11 @@ class CENDA_OT_ChangeFrame(Operator):
     bl_label = "Change Frame Drag"
     bl_options = {'UNDO_GROUPED', 'INTERNAL', 'GRAB_CURSOR', 'BLOCKING'}
 
-    if (is27):
+    class props:
         autoSensitivity = BoolProperty(name="Auto Sensitivity")
         defaultSensitivity = FloatProperty(name="Sensitivity", default=5)
         renderOnly = BoolProperty(name="Render Only", default=True)
-    if (is28):
-        autoSensitivity: BoolProperty(name="Auto Sensitivity")
-        defaultSensitivity: FloatProperty(name="Sensitivity", default=5)
-        renderOnly: BoolProperty(name="Render Only", default=True)
+    exec(register_props(props))
 
     global frameOffset
     global mouseOffset
@@ -181,12 +215,10 @@ class ChangeFrameDragAddonPreferences(AddonPreferences):
 
     bl_idname = __name__
 
-    if (is27):
+    class props:
         boolSmoothDrag = BoolProperty(name="Smooth Drag", default=True)
         boolSmoothSnap = BoolProperty(name="Snap after drag", default=True)
-    if (is28):
-        boolSmoothDrag: BoolProperty(name="Smooth Drag", default=True)
-        boolSmoothSnap: BoolProperty(name="Snap after drag", default=True)
+    exec(register_props(props))
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION


Convert formatting to PEP8 standards (mostly)
Added continuous mouse drag. 

Removed mouse defaults, and opting to only remember the key pressed on start. 
This will allow any hotkey to be set for this.  
I personally set it to SPACE (as CLICK_DRAG) in frames, and switch SPACE (PRESS) to SPACE (CLICK). This allows regular playback or sliding with the same button.  
Also tweaked code to work outside the 3D View.

I'd also like there to be an easy option somewhere that adds a hotkey, rather than it being completely manual (just idea, no effort placed in doing it)